### PR TITLE
Bump auth-service to v0.0.27

### DIFF
--- a/yggdrasil/applications/eo/eo-auth/eo-auth-service.yaml
+++ b/yggdrasil/applications/eo/eo-auth/eo-auth-service.yaml
@@ -2,7 +2,7 @@ eo-base-helm-chart:
   deployments:
     api:
       image:
-        tag: v0.0.29
+        tag: v0.0.27
   env:
     DEBUG: 1
     SERVICE_URL: https://{{ .Values.ingressDomain }}/api/auth


### PR DESCRIPTION
Bump auth-service to v0.0.27

- Triggered by [Job][1] in [Repo][2]

[1]: https://github.com/RasmusGodske/eo-auth/actions/runs/1577319485 
[2]: https://github.com/RasmusGodske/eo-auth