### PR TITLE
Bump eo-frontend to v0.0.29

### DIFF
--- a/yggdrasil/applications/eo/eo-frontend/eo-frontend.yaml
+++ b/yggdrasil/applications/eo/eo-frontend/eo-frontend.yaml
@@ -2,7 +2,7 @@ eo-base-helm-chart:
   deployments:
     app:
       image:
-        tag: v0.0.28
+        tag: v0.0.29
   ingress:
     hosts:
       - {{ .Values.ingressDomain }}


### PR DESCRIPTION
Bump eo-frontend to v0.0.29

- Triggered by [Job][1] in [Repo][2]

[1]: https://github.com/RasmusGodske/greenforce-frontend/actions/runs/1606301383 
[2]: https://github.com/RasmusGodske/greenforce-frontend